### PR TITLE
Correct the google java format integration with jitpack.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.2.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        //noinspection GradleDependency
+        classpath 'gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.8'
     }
 
     ext.build_tools_version = '30.0.3'
@@ -22,11 +21,7 @@ buildscript {
 }
 
 
-
-plugins {
-    id "com.github.sherter.google-java-format" version "0.8"
-}
-
+apply plugin: 'com.github.sherter.google-java-format'
 apply from: "${rootDir}/config/google_java_format.gradle"
 
 


### PR DESCRIPTION
 Otherwise, it gives the following error like https://jitpack.io/com/github/TonyTangAndroid/CrashReporter/0.0.4/build.log.

> Build file '/home/jitpack/build/build.gradle' line: 46
What went wrong:
Could not compile build file '/home/jitpack/build/build.gradle'.
> startup failed:
  build file '/home/jitpack/build/build.gradle': 46: all buildscript {} blocks must appear before any plugins {} blocks in the script
  See https://docs.gradle.org/6.8.3/userguide/plugins.html#sec:plugins_block for information on the plugins {} block
   @ line 46, column 1.
     buildscript {
     ^
  1 error
Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.